### PR TITLE
again

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
      
 FarPash大佬的项目https://github.com/TSIOJeft/WeChatPush    
 唐大土土大佬的软件https://www.coolapk.com/apk/top.tdtt.news    
-感谢酷安的大佬 大鸟转转转酒吧（ll2594） Away`LL（chase535） 两位的贡献。    
+感谢酷安的大佬 大鸟转转转酒吧（chase535） Away`LL （ll2594）两位的贡献。    
      
 运行前先执行命令 pip3 install requirements.txt 安装库文件
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FarPash大佬的项目https://github.com/TSIOJeft/WeChatPush
 唐大土土大佬的软件https://www.coolapk.com/apk/top.tdtt.news    
 感谢酷安的大佬 大鸟转转转酒吧（chase535） Away`LL （ll2594）两位的贡献。    
      
-运行前先执行命令 pip3 install requirements.txt 安装库文件
+运行前先执行命令 pip3 install -r requirements.txt 安装库文件
 
 程序配置文件config.txt，首次配置完成后方可运行main.py。若程序正在后台运行，则更改配置后实时生效
   

--- a/WeChatPush/itchat/async_components/login.py
+++ b/WeChatPush/itchat/async_components/login.py
@@ -41,14 +41,13 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
     self.isLogging = True
 
     while self.isLogging:
-        uuid = await push_login(self)
         logger.info('Getting uuid of QR code.')
         self.get_QRuuid()
         payload = EventScanPayload(
             status=ScanStatus.Waiting,
             qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
         )
-        print(f"http://wechaty.js.org/qrcode/http://login.weixin.qq.com/l/{self.uuid}")
+        print(f"https://wechaty.js.org/qrcode/http://login.weixin.qq.com/l/{self.uuid}")
         event_stream.emit('scan', payload)
         await asyncio.sleep(0.1)
         # logger.info('Please scan the QR code to log in.')
@@ -61,7 +60,7 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
                 isLoggedIn = True
                 payload = EventScanPayload(
                     status=ScanStatus.Scanned,
-                    qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
+                    qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
                 )
                 event_stream.emit('scan', payload)
                 await asyncio.sleep(0.1)
@@ -72,14 +71,14 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
                     time.sleep(10)
                     payload = EventScanPayload(
                         status=ScanStatus.Waiting,
-                        qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
+                        qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
                     )
                     event_stream.emit('scan', payload)
                     await asyncio.sleep(0.1)
             elif status != '408':
                 payload = EventScanPayload(
                     status=ScanStatus.Cancel,
-                    qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
+                    qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
                 )
                 event_stream.emit('scan', payload)
                 await asyncio.sleep(0.1)
@@ -87,7 +86,7 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
         if isLoggedIn:
             payload = EventScanPayload(
                 status=ScanStatus.Confirmed,
-                qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
+                qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
             )
             event_stream.emit('scan', payload)
             await asyncio.sleep(0.1)
@@ -96,7 +95,7 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
             logger.info('Log in time out, reloading QR code.')
             payload = EventScanPayload(
                 status=ScanStatus.Timeout,
-                qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
+                qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
             )
             event_stream.emit('scan', payload)
             await asyncio.sleep(0.1)
@@ -133,7 +132,7 @@ def get_QRuuid(self):
     params = {
         'appid' : 'wx782c26e4c19acffb',
         'fun'   : 'new',
-        'redirect_uri' : 'http://wx.qq.com/cgi-bin/mmwebwx-bin/webwxnewloginpage?mod=desktop',
+        'redirect_uri' : 'https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxnewloginpage?mod=desktop',
         'lang'  : 'zh_CN' }
     headers = { 'User-Agent' : config.USER_AGENT}
     r = self.s.get(url, params=params, headers=headers)
@@ -147,7 +146,7 @@ async def get_QR(self, uuid=None, enableCmdQR=False, picDir=None, qrCallback=Non
     uuid = uuid or self.uuid
     picDir = picDir or config.DEFAULT_QR
     qrStorage = io.BytesIO()
-    qrCode = QRCode('http://login.weixin.qq.com/l/' + uuid)
+    qrCode = QRCode('https://login.weixin.qq.com/l/' + uuid)
     qrCode.png(qrStorage, scale=10)
     if hasattr(qrCallback, '__call__'):
         await qrCallback(uuid=uuid, status='0', qrcode=qrStorage.getvalue())
@@ -191,7 +190,7 @@ async def process_login_info(core, loginContent):
     headers = { 'User-Agent' : config.USER_AGENT,
                 'client-version' : config.UOS_PATCH_CLIENT_VERSION,
                 'extspam' : config.UOS_PATCH_EXTSPAM,
-                'referer' : 'http://wx.qq.com/?&lang=zh_CN&target=t'
+                'referer' : 'https://wx.qq.com/?&lang=zh_CN&target=t'
               }
     r = core.s.get(core.loginInfo['url'], headers=headers, allow_redirects=False)
     core.loginInfo['url'] = core.loginInfo['url'][:core.loginInfo['url'].rfind('/')]
@@ -201,7 +200,7 @@ async def process_login_info(core, loginContent):
             ("qq.com"          , ("file.wx.qq.com", "webpush.wx.qq.com")),
             ("web2.wechat.com" , ("file.web2.wechat.com", "webpush.web2.wechat.com")),
             ("wechat.com"      , ("file.web.wechat.com", "webpush.web.wechat.com"))):
-        fileUrl, syncUrl = ['http://%s/cgi-bin/mmwebwx-bin' % url for url in detailedUrl]
+        fileUrl, syncUrl = ['https://%s/cgi-bin/mmwebwx-bin' % url for url in detailedUrl]
         if indexUrl in core.loginInfo['url']:
             core.loginInfo['fileUrl'], core.loginInfo['syncUrl'] = \
                 fileUrl, syncUrl

--- a/WeChatPush/itchat/async_components/login.py
+++ b/WeChatPush/itchat/async_components/login.py
@@ -42,24 +42,16 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
 
     while self.isLogging:
         uuid = await push_login(self)
-        if uuid:
-            payload = EventScanPayload(
-                status=ScanStatus.Waiting,
-                qrcode=f"qrcode/https://login.weixin.qq.com/l/{uuid}"
-            )
-            event_stream.emit('scan', payload)
-            await asyncio.sleep(0.1)
-        else:
-            logger.info('Getting uuid of QR code.')
-            self.get_QRuuid()
-            payload = EventScanPayload(
-                status=ScanStatus.Waiting,
-                qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
-            )
-            print(f"https://wechaty.js.org/qrcode/https://login.weixin.qq.com/l/{self.uuid}")
-            event_stream.emit('scan', payload)
-            await asyncio.sleep(0.1)
-            # logger.info('Please scan the QR code to log in.')
+        logger.info('Getting uuid of QR code.')
+        self.get_QRuuid()
+        payload = EventScanPayload(
+            status=ScanStatus.Waiting,
+            qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
+        )
+        print(f"http://wechaty.js.org/qrcode/http://login.weixin.qq.com/l/{self.uuid}")
+        event_stream.emit('scan', payload)
+        await asyncio.sleep(0.1)
+        # logger.info('Please scan the QR code to log in.')
         isLoggedIn = False
         while not isLoggedIn:
             status = await self.check_login()
@@ -69,24 +61,25 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
                 isLoggedIn = True
                 payload = EventScanPayload(
                     status=ScanStatus.Scanned,
-                    qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
+                    qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
                 )
                 event_stream.emit('scan', payload)
                 await asyncio.sleep(0.1)
             elif status == '201':
                 if isLoggedIn is not None:
-                    logger.info('Please press confirm on your phone.')
+                    logger.info('Please press confirm on your phone in 10 sec.')
                     isLoggedIn = None
+                    time.sleep(10)
                     payload = EventScanPayload(
                         status=ScanStatus.Waiting,
-                        qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
+                        qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
                     )
                     event_stream.emit('scan', payload)
                     await asyncio.sleep(0.1)
             elif status != '408':
                 payload = EventScanPayload(
                     status=ScanStatus.Cancel,
-                    qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
+                    qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
                 )
                 event_stream.emit('scan', payload)
                 await asyncio.sleep(0.1)
@@ -94,7 +87,7 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
         if isLoggedIn:
             payload = EventScanPayload(
                 status=ScanStatus.Confirmed,
-                qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
+                qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
             )
             event_stream.emit('scan', payload)
             await asyncio.sleep(0.1)
@@ -103,7 +96,7 @@ async def login(self, enableCmdQR=False, picDir=None, qrCallback=None, EventScan
             logger.info('Log in time out, reloading QR code.')
             payload = EventScanPayload(
                 status=ScanStatus.Timeout,
-                qrcode=f"https://login.weixin.qq.com/l/{self.uuid}"
+                qrcode=f"http://login.weixin.qq.com/l/{self.uuid}"
             )
             event_stream.emit('scan', payload)
             await asyncio.sleep(0.1)
@@ -140,7 +133,7 @@ def get_QRuuid(self):
     params = {
         'appid' : 'wx782c26e4c19acffb',
         'fun'   : 'new',
-        'redirect_uri' : 'https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxnewloginpage?mod=desktop',
+        'redirect_uri' : 'http://wx.qq.com/cgi-bin/mmwebwx-bin/webwxnewloginpage?mod=desktop',
         'lang'  : 'zh_CN' }
     headers = { 'User-Agent' : config.USER_AGENT}
     r = self.s.get(url, params=params, headers=headers)
@@ -154,7 +147,7 @@ async def get_QR(self, uuid=None, enableCmdQR=False, picDir=None, qrCallback=Non
     uuid = uuid or self.uuid
     picDir = picDir or config.DEFAULT_QR
     qrStorage = io.BytesIO()
-    qrCode = QRCode('https://login.weixin.qq.com/l/' + uuid)
+    qrCode = QRCode('http://login.weixin.qq.com/l/' + uuid)
     qrCode.png(qrStorage, scale=10)
     if hasattr(qrCallback, '__call__'):
         await qrCallback(uuid=uuid, status='0', qrcode=qrStorage.getvalue())
@@ -198,7 +191,7 @@ async def process_login_info(core, loginContent):
     headers = { 'User-Agent' : config.USER_AGENT,
                 'client-version' : config.UOS_PATCH_CLIENT_VERSION,
                 'extspam' : config.UOS_PATCH_EXTSPAM,
-                'referer' : 'https://wx.qq.com/?&lang=zh_CN&target=t'
+                'referer' : 'http://wx.qq.com/?&lang=zh_CN&target=t'
               }
     r = core.s.get(core.loginInfo['url'], headers=headers, allow_redirects=False)
     core.loginInfo['url'] = core.loginInfo['url'][:core.loginInfo['url'].rfind('/')]
@@ -208,7 +201,7 @@ async def process_login_info(core, loginContent):
             ("qq.com"          , ("file.wx.qq.com", "webpush.wx.qq.com")),
             ("web2.wechat.com" , ("file.web2.wechat.com", "webpush.web2.wechat.com")),
             ("wechat.com"      , ("file.web.wechat.com", "webpush.web.wechat.com"))):
-        fileUrl, syncUrl = ['https://%s/cgi-bin/mmwebwx-bin' % url for url in detailedUrl]
+        fileUrl, syncUrl = ['http://%s/cgi-bin/mmwebwx-bin' % url for url in detailedUrl]
         if indexUrl in core.loginInfo['url']:
             core.loginInfo['fileUrl'], core.loginInfo['syncUrl'] = \
                 fileUrl, syncUrl

--- a/WeChatPush/itchat/async_components/messages.py
+++ b/WeChatPush/itchat/async_components/messages.py
@@ -103,7 +103,10 @@ def produce_msg(core, msgList):
         elif m.get('MsgType') == 48:
             msg['Type'] = 'Location'
         elif m.get('MsgType') == 49:  # sharing
-            if msg.get('Name') == None:
+            if m.get('FromUserName') == 'weixin':
+                msg['Type'] = 'Servicenotification'
+                msg['Text'] = m.get('FileName')
+            elif msg.get('Name') == None:
                 msg['Name'] = msg['NickName'] = '服务通知'
                 msg['Type'] = 'Servicenotification'
                 msg['Text'] = m.get('FileName')

--- a/WeChatPush/itchat/components/login.py
+++ b/WeChatPush/itchat/components/login.py
@@ -44,7 +44,6 @@ def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
         return
     self.isLogging = True
     while self.isLogging:
-        uuid = push_login(self)
         logger.info('Getting uuid of QR code.')
         while not self.get_QRuuid():
             time.sleep(1)
@@ -106,7 +105,7 @@ def get_QRuuid(self):
     params = {
         'appid': 'wx782c26e4c19acffb',
         'fun': 'new',
-        'redirect_uri': 'http://wx.qq.com/cgi-bin/mmwebwx-bin/webwxnewloginpage?mod=desktop',
+        'redirect_uri': 'https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxnewloginpage?mod=desktop',
         'lang': 'zh_CN'}
     headers = {'User-Agent': config.USER_AGENT}
     r = self.s.get(url, params=params, headers=headers)
@@ -121,7 +120,7 @@ def get_QR(self, uuid=None, enableCmdQR=False, picDir=None, qrCallback=None):
     uuid = uuid or self.uuid
     picDir = picDir or config.DEFAULT_QR
     qrStorage = io.BytesIO()
-    qrCode = QRCode('http://login.weixin.qq.com/l/' + uuid)
+    qrCode = QRCode('https://login.weixin.qq.com/l/' + uuid)
     qrCode.png(qrStorage, scale=10)
     if hasattr(qrCallback, '__call__'):
         qrCallback(uuid=uuid, status='0', qrcode=qrStorage.getvalue())
@@ -167,7 +166,7 @@ def process_login_info(core, loginContent):
     headers = {'User-Agent': config.USER_AGENT,
                'client-version': config.UOS_PATCH_CLIENT_VERSION,
                'extspam': config.UOS_PATCH_EXTSPAM,
-               'referer': 'http://wx.qq.com/?&lang=zh_CN&target=t'
+               'referer': 'https://wx.qq.com/?&lang=zh_CN&target=t'
                }
     r = core.s.get(core.loginInfo['url'],
                    headers=headers, allow_redirects=False)
@@ -179,7 +178,7 @@ def process_login_info(core, loginContent):
             ("qq.com", ("file.wx.qq.com", "webpush.wx.qq.com")),
             ("web2.wechat.com", ("file.web2.wechat.com", "webpush.web2.wechat.com")),
             ("wechat.com", ("file.web.wechat.com", "webpush.web.wechat.com"))):
-        fileUrl, syncUrl = ['http://%s/cgi-bin/mmwebwx-bin' %
+        fileUrl, syncUrl = ['https://%s/cgi-bin/mmwebwx-bin' %
                             url for url in detailedUrl]
         if indexUrl in core.loginInfo['url']:
             core.loginInfo['fileUrl'], core.loginInfo['syncUrl'] = \

--- a/WeChatPush/itchat/components/login.py
+++ b/WeChatPush/itchat/components/login.py
@@ -44,6 +44,7 @@ def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
         return
     self.isLogging = True
     while self.isLogging:
+        uuid = push_login(self)
         logger.info('Getting uuid of QR code.')
         while not self.get_QRuuid():
             time.sleep(1)

--- a/WeChatPush/itchat/components/login.py
+++ b/WeChatPush/itchat/components/login.py
@@ -190,8 +190,8 @@ def process_login_info(core, loginContent):
     core.loginInfo['logintime'] = int(time.time() * 1e3)
     core.loginInfo['BaseRequest'] = {}
     cookies = core.s.cookies.get_dict()
-    skey = re.findall('<skey>(.*?)</skey>', r.text, re.S)
-    pass_ticket = re.findall('<pass_ticket>(.*?)</pass_ticket>', r.text, re.S)
+    skey = re.findall('<skey>(.*?)</skey>', r.text, re.S)[0]
+    pass_ticket = re.findall('<pass_ticket>(.*?)</pass_ticket>', r.text, re.S)[0]
     core.loginInfo['skey'] = core.loginInfo['BaseRequest']['Skey'] = skey
     core.loginInfo['wxsid'] = core.loginInfo['BaseRequest']['Sid'] = cookies["wxsid"]
     core.loginInfo['wxuin'] = core.loginInfo['BaseRequest']['Uin'] = cookies["wxuin"]

--- a/WeChatPush/itchat/components/messages.py
+++ b/WeChatPush/itchat/components/messages.py
@@ -110,7 +110,10 @@ def produce_msg(core, msgList):
         elif m.get('MsgType') == 48:
             msg['Type'] = 'Location'
         elif m.get('MsgType') == 49:  # sharing
-            if msg.get('Name') == None:
+            if m.get('FromUserName') == 'weixin':
+                msg['Type'] = 'Servicenotification'
+                msg['Text'] = m.get('FileName')
+            elif msg.get('Name') == None:
                 msg['Name'] = msg['NickName'] = '服务通知'
                 msg['Type'] = 'Servicenotification'
                 msg['Text'] = m.get('FileName')

--- a/WeChatPush/itchat/components/register.py
+++ b/WeChatPush/itchat/components/register.py
@@ -99,7 +99,7 @@ def run(self, debug=False, blockThread=True):
         try:
             while self.alive:
                 self.configured_reply()
-            logger.info('Warning', 'Login out')
+            logger.warning('Login out')
         except KeyboardInterrupt:
             if self.useHotReload:
                 self.dump_login_status()

--- a/WeChatPush/itchat/config.py
+++ b/WeChatPush/itchat/config.py
@@ -5,7 +5,7 @@ VERSION = '1.5.0.dev'
 # use this envrionment to initialize the async & sync componment
 ASYNC_COMPONENTS = os.environ.get('ITCHAT_UOS_ASYNC', False)
 
-BASE_URL = 'https://login.weixin.qq.com'
+BASE_URL = 'http://login.weixin.qq.com'
 OS = platform.system()  # Windows, Linux, Darwin
 DIR = os.getcwd()
 DEFAULT_QR = 'QR.png'


### PR DESCRIPTION
1、微信官方禁止了网页版微信快速登录（在上次登录的设备上无需扫码即可登录），只能扫码登陆，所以删除快速登陆，长时间不登录、在其他设备上登录、手动退出等都需重新扫码登录
2、登录页https改为http，增强兼容性
3、我也发现了`farpush.mespush`不存在，然后发现你修复了这个臭虫，好耶
4、README.md名字写反了（